### PR TITLE
Fixed capturing groups are now named

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Here is an example of configuration for COBOL 'A':
 
 		"executeCurrentStatement": {
 			"name": "step",
-			"successRegularExpression": "\\s+Current\\s+statement:\\s+line:(\\d+)\\s+->\\s+([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "\\s+Current\\s+statement:\\s+line:(?<linenumber>\\d+)\\s+->\\s+(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 
 Here is an example of configuration for COBOL 'B':
 
 		"executeCurrentStatement": {
 			"name": "execute",
-			"successRegularExpression": "\\s+Stopped\s+at\s+line\s+(\d+)\s+and\s+file\s+([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "\\s+Stopped\s+at\s+line\s+(?<linenumber>\d+)\s+and\s+file\s+(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 
-**IMPORTANT**: remember that, on JSON files, you need to escape backslash with another backslash, so this is why '\\\\s+' appears with double backslash. Also notice that some commands, like the one shown above, requires regular expression groups on the exact order: first group related to line number and second group related to file path. If you specify a custom regular expression, be careful with the position of the groups.
+**IMPORTANT**: remember that, on JSON files, you need to escape backslash with another backslash, so this is why '\\\\s+' appears with double backslash. Also notice that some commands, like the one shown above, requires regular expression with named groups: group 'linenumber' is related to line number and group 'path' is related to file path. If you specify a custom regular expression, please keep the groups with these names, although they don't need to be in any specific order.
 
 The default configuration file is *defaultDebugConfigs.json* located on project root. To provide custom commands, copy this file to any folder on your computer, rename the way you prefer and define the path to this file at **rech.cobol.debug.externalDebugConfigs** setting.
 

--- a/defaultDebugConfigs.json
+++ b/defaultDebugConfigs.json
@@ -2,31 +2,31 @@
 	"commands": {
 		"currentLineInfo": {
 			"name": "line",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"executeCurrentStatement": {
 			"name": "step",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"stepOutCurrentParagraph": {
 			"name": "outpar",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"stepOutCurrentProgram": {
 			"name": "outprog",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"runToNextProgram": {
 			"name": "prog",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"continueProgramExecution": {
 			"name": "continue",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"executeCurrentStatementAndBlock": {
 			"name": "next",
-			"successRegularExpression": "^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)"
+			"successRegularExpression": "^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)"
 		},
 		"suspendProgramExecution": {
 			"name": "pause"
@@ -92,7 +92,7 @@
 		},
 		"addBreakpointOnLocation": {
 			"name": "break",
-			"successRegularExpression": "set\\sbreakpoint\\s(at|in)\\s(line|paragraph)\\s.*\\,\\sfile\\s([\\w\\.:\\\/ \\-]+)",
+			"successRegularExpression": "set\\sbreakpoint\\s(at|in)\\s(line|paragraph)\\s.*\\,\\sfile\\s(?<path>[\\w\\.:\\\/ \\-]+)",
 			"extraRegularExpressions": [
 				"no\\sverb\\s(at|in)\\s(line|paragraph)\\s.*\\,\\sfile\\s.*",
 				"no\\s+such\\s+file",
@@ -110,7 +110,7 @@
 		},
 		"listBreakpoints": {
 			"name": "break -l",
-			"successRegularExpression": "\\[line:\\s+([0-9]+)\\,\\s+file:\\s+([\\w\\.]+).*\\]"
+			"successRegularExpression": "\\[line:\\s+(?<linenumber>[0-9]+)\\,\\s+file:\\s+(?<path>[\\w\\.]+).*\\]"
 		}
 	},
 	"executionFinishedRegularExpressions": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rech-cobol-debugger",
 	"displayName": "Rech COBOL Debugger",
 	"description": "Debug COBOL files with Visual Studio Code",
-	"version": "1.0.34",
+	"version": "1.0.35",
 	"publisher": "rechinformatica",
 	"engines": {
 		"vscode": "^1.43.0"

--- a/src/debugProcess/AddBreakpointCommand.ts
+++ b/src/debugProcess/AddBreakpointCommand.ts
@@ -3,9 +3,7 @@ import { CobolParagraphBreakpoint } from "../breakpoint/CobolParagraphBreakpoint
 import { CommandUtils } from "./CommandUtils";
 import { ICommand } from "./DebugConfigs";
 import { GenericDebugCommand } from "./GenericDebugCommand";
-
-/** Index where filename can be found on regular expression of breakpoint commands */
-const FILENAME_BREAKPOINT_CMD_OUTPUT = 3;
+import { PATH_NAMED_GROUP } from "./PositionConstants";
 
 /**
  * Class to handle command to add breakpoint
@@ -28,12 +26,13 @@ export class AddBreakpointCommand implements DebugCommand<CobolParagraphBreakpoi
 			return undefined;
 		}
 		const regexResult = new RegExp(this.command.successRegularExpression, "i").exec(output);
-		if (regexResult) {
+		if (regexResult && regexResult.groups) {
 			// Returns the breakpoint full filename
-			return regexResult[FILENAME_BREAKPOINT_CMD_OUTPUT];
-		} else {
-			return undefined;
+			const groups = regexResult.groups;
+			const filePath = groups[PATH_NAMED_GROUP];
+			return filePath;
 		}
+		return undefined;
 	}
 
 	/**

--- a/src/debugProcess/DebugPositionCommand.ts
+++ b/src/debugProcess/DebugPositionCommand.ts
@@ -2,11 +2,7 @@ import { DebugCommand } from "./DebugCommand";
 import { DebugPosition } from "./DebugPosition";
 import { ICommand } from "./DebugConfigs";
 import { GenericDebugCommand } from "./GenericDebugCommand";
-
-/** Index inside match where the line number can be extracted */
-const MATCH_LINE_INDEX = 1;
-/** Index inside match where the file name can be extracted */
-const MATCH_FILE_INDEX = 2;
+import { PATH_NAMED_GROUP, LINE_NAMED_GROUP } from "./PositionConstants";
 
 /**
  * Class to handle several commands which return a debug position
@@ -28,12 +24,17 @@ export class DebugPositionCommand implements DebugCommand<void, DebugPosition | 
 	validateOutput(output: string): DebugPosition | undefined {
 		const successRegExp = this.command.successRegularExpression;
 		const match = successRegExp ? new RegExp(successRegExp, "im").exec(output) : undefined;
-		if (match && match.length > MATCH_FILE_INDEX) {
-			return ({
-				file: match[MATCH_FILE_INDEX],
-				line: new Number(match[MATCH_LINE_INDEX]).valueOf(),
-				output: output
-			});
+		if (match && match.groups) {
+			const groups = match.groups;
+			const file = groups[PATH_NAMED_GROUP];
+			const line = groups[LINE_NAMED_GROUP];
+			if (file && line) {
+				return ({
+					file: file,
+					line: new Number(line).valueOf(),
+					output: output
+				});
+			}
 		}
 		return undefined;
 	}

--- a/src/debugProcess/ListBreakpointsCommand.ts
+++ b/src/debugProcess/ListBreakpointsCommand.ts
@@ -2,9 +2,7 @@ import { DebugCommand } from "./DebugCommand";
 import { CobolBreakpoint } from "../breakpoint/CobolBreakpoint";
 import { ICommand } from "./DebugConfigs";
 import { GenericDebugCommand } from "./GenericDebugCommand";
-
-/** Index where filename can be found on regular expression of list command */
-const FILENAME_LIST_CMD_OUTPUT = 2;
+import { PATH_NAMED_GROUP, LINE_NAMED_GROUP } from "./PositionConstants";
 
 /**
  * Class to handle list breakpoints command
@@ -38,9 +36,15 @@ export class ListBreakpointsCommand implements DebugCommand<void, CobolBreakpoin
 		if (regex) {
 			let result: RegExpExecArray | null = null;
 			while ((result = regex.exec(output)) !== null) {
-				const line = +result[1];
-				const source = result[FILENAME_LIST_CMD_OUTPUT];
-				breaks.push({ line: line, source: source });
+				const groups = result.groups;
+				if (groups) {
+					const file = groups[PATH_NAMED_GROUP];
+					const line = groups[LINE_NAMED_GROUP];
+					breaks.push({
+						line: new Number(line).valueOf(),
+						source: file
+					});
+				}
 			}
 		}
 		return breaks;

--- a/src/debugProcess/PositionConstants.ts
+++ b/src/debugProcess/PositionConstants.ts
@@ -1,0 +1,4 @@
+/** Named group where the line number can be extracted */
+export const LINE_NAMED_GROUP = 'linenumber';
+/** Named group where the file name can be extracted */
+export const PATH_NAMED_GROUP = 'path';

--- a/src/test/debugProcess/AddBreakpointCommand.test.ts
+++ b/src/test/debugProcess/AddBreakpointCommand.test.ts
@@ -5,7 +5,7 @@ import { ICommand } from '../../debugProcess/DebugConfigs';
 
 const COMMAND: ICommand = {
     name: 'break',
-    successRegularExpression: 'set\\sbreakpoint\\s(at|in)\\s(line|paragraph)\\s.*\\,\\sfile\\s([\\w\\.:\\\/ \\-]+)',
+    successRegularExpression: 'set\\sbreakpoint\\s(at|in)\\s(line|paragraph)\\s.*\\,\\sfile\\s(?<path>[\\w\\.:\\\/ \\-]+)',
     extraRegularExpressions: [
         'no\\sverb\\s(at|in)\\s(line|paragraph)\\s.*\\,\\sfile\\s.*',
         'no\\s+such\\s+file',

--- a/src/test/debugProcess/DebugPositionCommand.test.ts
+++ b/src/test/debugProcess/DebugPositionCommand.test.ts
@@ -6,7 +6,7 @@ import { ICommand } from '../../debugProcess/DebugConfigs';
 
 const COMMAND: ICommand = {
     name: 'line',
-    successRegularExpression: '^\\+*\\s+line=(\\d+)\\s+file=([\\w\\.:\\\/ \\-]+)'
+    successRegularExpression: '^\\+*\\s+line=(?<linenumber>\\d+)\\s+file=(?<path>[\\w\\.:\\\/ \\-]+)'
 }
 
 describe('Debug position command', () => {
@@ -58,6 +58,25 @@ describe('Debug position command', () => {
             '            if sig-debug-sim                                                                                              *>   61570      44';
         const result = new DebugPositionCommand(COMMAND).validateOutput(output);
         expect(undefined).to.equal(result);
+    });
+
+    it('Checks with different compiler output', () => {
+        const differentCommand : ICommand = {
+            name: 'line',
+            successRegularExpression: '(?:-event.+at\\s+)(?<path>.+)!\\s*(?<linenumber>\\d+)'
+        };
+        const output =
+            '-event-end-stepping-range #0 cobio_ext_fh () at /home/user/projects/cobol/demo02.cob!68\n' +
+            '            accept                 w-sig-debug from environment-value.                                                    *>   61568      42\n' +
+            '+ changed variables: \n' +
+            ' W-SIG-DEBUG [SRIM00] = S\n' +
+            ' dummy message instead of line and file\n' +
+            '            if sig-debug-sim                                                                                              *>   61570      44';
+        const expected: DebugPosition = {file: '/home/user/projects/cobol/demo02.cob', line: 68, output: output};
+        const result = new DebugPositionCommand(differentCommand).validateOutput(output);
+        expect(expected.file).to.equal(result!.file);
+        expect(expected.line).to.equal(result!.line);
+        expect(expected.output).to.equal(result!.output);
     });
 
 });

--- a/src/test/debugProcess/ListBreakpointsCommand.test.ts
+++ b/src/test/debugProcess/ListBreakpointsCommand.test.ts
@@ -6,7 +6,7 @@ import { ICommand } from '../../debugProcess/DebugConfigs';
 
 const COMMAND: ICommand = {
     name: 'break -l',
-    successRegularExpression: '\\[line:\\s+([0-9]+)\\,\\s+file:\\s+([\\w\\.]+).*\\]'
+    successRegularExpression: '\\[line:\\s+(?<linenumber>[0-9]+)\\,\\s+file:\\s+(?<path>[\\w\\.]+).*\\]'
 }
 
 describe('List breakpoints command', () => {
@@ -74,6 +74,43 @@ describe('List breakpoints command', () => {
             }
         ];
         const result = new ListBreakpointsCommand(COMMAND).validateOutput(output);
+        expect(expected.length).to.equal(result.length);
+        for (let i = 0; i < result.length; i++) {
+            expect(expected[i].line).to.equal(result[i].line);
+            expect(expected[i].source).to.equal(result[i].source);
+        }
+    });
+
+    it('List with 4 valid breakpoints in reverse order', () => {
+        const reverseOrderCommand: ICommand = {
+            name: 'break -l',
+            successRegularExpression: '\\[file:\\s+(?<path>[\\w\\.]+)\\,\\s+line:\\s+(?<linenumber>[0-9]+).*\\]'
+        }
+        const output =
+            '[file: srhped.cbl, line: 390019]\n' +
+            '[file: SRIM00.CBL, line: 57368]\n' +
+            '[dummy: 83207, dummy: ctb005.cbl]\n' +
+            '[file: SRIM00.CBL, line: 57376]\n' +
+            '[file: srhgnf.cbl, line: 379851, index: 0]';
+        const expected: CobolBreakpoint[] = [
+            {
+                line: 390019,
+                source: 'srhped.cbl'
+            },
+            {
+                line: 57368,
+                source: 'SRIM00.CBL'
+            },
+            {
+                line: 57376,
+                source: 'SRIM00.CBL'
+            },
+            {
+                line: 379851,
+                source: 'srhgnf.cbl'
+            }
+        ];
+        const result = new ListBreakpointsCommand(reverseOrderCommand).validateOutput(output);
         expect(expected.length).to.equal(result.length);
         for (let i = 0; i < result.length; i++) {
             expect(expected[i].line).to.equal(result[i].line);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es6",
+    "target": "es2018",
     "module": "commonjs",
     "lib": [
-      "es6"
+      "es2018"
     ],
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */


### PR DESCRIPTION
This PR makes capturing groups to be named, so they can be accessed on any order within regular expressions.