### PR TITLE
Now debug adapter looks for fallback directories

### DIFF
--- a/defaultDebugConfigs.json
+++ b/defaultDebugConfigs.json
@@ -111,6 +111,10 @@
 		"listBreakpoints": {
 			"name": "break -l",
 			"successRegularExpression": "\\[line:\\s+(?<linenumber>[0-9]+)\\,\\s+file:\\s+(?<path>[\\w\\.]+).*\\]"
+		},
+		"requestAvailableSourceDirectories": {
+			"name": "display -env java.class.path",
+			"successRegularExpression": ".*java\\.class\\.path\\s+=\\s+(?<directories>.*)"
 		}
 	},
 	"executionFinishedRegularExpressions": [

--- a/src/debugProcess/DebugConfigs.ts
+++ b/src/debugProcess/DebugConfigs.ts
@@ -73,6 +73,7 @@ export interface IDebugCommands {
 	addVariableMonitor: ICommand
 	removeVariableMonitor: ICommand
 	removeAllVariableMonitors: ICommand
+	requestAvailableSourceDirectories?: ICommand
 }
 
 export interface ICommand {

--- a/src/debugProcess/FallbackDirectoriesFinder.ts
+++ b/src/debugProcess/FallbackDirectoriesFinder.ts
@@ -1,0 +1,67 @@
+import * as path from "path";
+import * as fs from "fs";
+import { ExternalDebugAdapter } from "./ExternalDebugAdapter";
+
+/**
+ * Class to look for files on fallback directories
+ */
+export class FallbackDirectoriesFinder {
+
+	private cachedFiles: Map<string, string> = new Map();
+	private cachedAvailableSourceDirectories: string[] | undefined;
+
+	constructor(private externalDebugAdaptar: ExternalDebugAdapter) { }
+
+	public lookForSourceOnFallbackDirectories(fileName: string): Promise<string | undefined> {
+		return new Promise((resolve, reject) => {
+			this.requestAvailableSourceDirectories().then(directories => {
+				const fullPath = directories ? this.lookOnLoadedFallbackDirectories(directories, fileName) : undefined;
+				return resolve(fullPath);
+			}).catch(error => reject(error));
+		});
+	}
+
+	private lookOnLoadedFallbackDirectories(directories: string[], fileName: string): string | undefined {
+		for (let i = 0; i < directories.length; i++) {
+			const fullPath = this.lookForFileOnDirectory(directories[i], fileName);
+			if (fullPath) {
+				return fullPath;
+			}
+		}
+		return undefined;
+	}
+
+	public lookForFileOnDirectory(currentDir: string, fileName: string): string | undefined {
+		const cached = this.cachedFiles.get(fileName);
+		return cached ? cached : this.lookForFileWithoutCache(currentDir, fileName);
+	}
+
+	private lookForFileWithoutCache(currentDir: string, fileName: string): string | undefined {
+		const fileOnCurrentDirectory = this.addSeparatorIfNeeded(currentDir.trim()) + fileName;
+		if (fs.existsSync(fileOnCurrentDirectory)) {
+			this.cachedFiles.set(fileName, fileOnCurrentDirectory);
+			return fileOnCurrentDirectory;
+		}
+		return undefined;
+	}
+
+	private requestAvailableSourceDirectories(): Promise<string[] | undefined> {
+		return new Promise((resolve, reject) => {
+			if (this.cachedAvailableSourceDirectories) {
+				return resolve(this.cachedAvailableSourceDirectories);
+			}
+			this.externalDebugAdaptar.requestAvailableSourceDirectories().then(directories => {
+				this.cachedAvailableSourceDirectories = directories;
+				return resolve(directories);
+			}).catch(error => reject(error));
+		});
+	}
+
+	private addSeparatorIfNeeded(directory: string): string {
+		if (directory.endsWith("\\") || directory.endsWith("/")) {
+			return directory;
+		}
+		return directory + path.sep;
+	}
+
+}

--- a/src/debugProcess/RequestAvailableSourceDirectoriesCommand.ts
+++ b/src/debugProcess/RequestAvailableSourceDirectoriesCommand.ts
@@ -1,0 +1,34 @@
+import { DebugCommand } from "./DebugCommand";
+import { ICommand } from "./DebugConfigs";
+import { GenericDebugCommand } from "./GenericDebugCommand";
+
+/** Named group where the file name can be extracted */
+export const AVAILABLE_DIRECTORIES_NAMED_GROUP = 'directories';
+
+/**
+ * Class to handle command to request available source directories
+ */
+export class RequestAvailableSourceDirectoriesCommand implements DebugCommand<void, string[] | undefined> {
+
+	constructor(private command: ICommand) {}
+
+	buildCommand(): string {
+		return new GenericDebugCommand(this.command).buildCommand();
+	}
+
+	getExpectedRegExes(): RegExp[] {
+		return new GenericDebugCommand(this.command).getExpectedRegExes();
+	}
+
+	validateOutput(output: string): string[] | undefined {
+		const successRegExp = this.command.successRegularExpression;
+		const match = successRegExp ? new RegExp(successRegExp, "im").exec(output) : undefined;
+		if (match && match.groups) {
+			const groups = match.groups;
+			const directories = groups[AVAILABLE_DIRECTORIES_NAMED_GROUP];
+			const splitted = directories.split(';');
+			return splitted;
+		}
+	}
+
+}

--- a/src/test/debugProcess/ExternalDebugAdapter.test.ts
+++ b/src/test/debugProcess/ExternalDebugAdapter.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import 'mocha';
-import * as path from "path";
 import { ExternalDebugAdapter } from '../../debugProcess/ExternalDebugAdapter';
 import { ProcessProvider } from '../../debugProcess/ProcessProvider';
 import { DebugPosition } from '../../debugProcess/DebugPosition';
@@ -19,30 +18,6 @@ describe('External debug adapter', () => {
         const expected: DebugPosition = { file: 'F:/SIGER/wc/DES/lucas-camargo/src/isCOBOL/debug/PDV201.CBL', line: 75151, output: 'dummy' };
         const adapter = new ExternalDebugAdapter("dummyCommandLine", () => { }, "", "", new HitBreakpointProvider());
         const result = await adapter.stepIn();
-        expect(expected.file).to.equal(result.file);
-        expect(expected.line).to.equal(result.line);
-    });
-
-    it('Hits breakpoint on step in without partial filename on step', async () => {
-        const expected: DebugPosition = { file: `C:\\Bases\\Amcm\\20.20${path.sep}PDV201.CBL`, line: 75151, output: 'dummy' };
-        const adapter = new ExternalDebugAdapter("dummyCommandLine", () => { }, "", "", new HitBreakpointPartialFileNameProvider());
-        const result = await adapter.stepIn();
-        expect(expected.file).to.equal(result.file);
-        expect(expected.line).to.equal(result.line);
-    });
-
-    it('Hits breakpoint on step in without partial filename with separator on step', async () => {
-        const expected: DebugPosition = { file: `C:\\Bases\\Amcm\\20.20${path.sep}PDV201.CBL`, line: 75151, output: 'dummy' };
-        const adapter = new ExternalDebugAdapter("dummyCommandLine", () => { }, "", "", new HitBreakpointPartialFileNameWithSeparatorProvider());
-        const result = await adapter.stepIn();
-        expect(expected.file).to.equal(result.file);
-        expect(expected.line).to.equal(result.line);
-    });
-
-    it('Hits breakpoint on continue without partial filename on step', async () => {
-        const expected: DebugPosition = { file: `C:\\Bases\\Amcm\\20.20${path.sep}PDV201.CBL`, line: 75151, output: 'dummy' };
-        const adapter = new ExternalDebugAdapter("dummyCommandLine", () => { }, "", "", new HitBreakpointPartialFileNameProvider());
-        const result = await adapter.continue();
         expect(expected.file).to.equal(result.file);
         expect(expected.line).to.equal(result.line);
     });
@@ -188,48 +163,6 @@ class HitBreakpointProvider extends BaseMockProvider {
             ' line=75151 file=F:/SIGER/wc/DES/lucas-camargo/src/isCOBOL/debug/PDV201.CBL\n' +
             '         pcpr-configuracao.                                                                                                *>  107606     780\n' +
             'isdb>';
-    }
-
-}
-
-enum Stage { Step, GetCurrentDirectory };
-
-class HitBreakpointPartialFileNameProvider extends BaseMockProvider {
-
-    private stage: Stage = Stage.Step;
-
-    getOutputContent(): string {
-        if (this.stage == Stage.Step) {
-            this.stage = Stage.GetCurrentDirectory;
-            return ' \n' +
-                ' + hit breakpoint in paragraph PCPR-CONFIGURACAO, file PDV201.CBL\n' +
-                ' line=75151 file=PDV201.CBL\n' +
-                '         pcpr-configuracao.                                                                                                *>  107606     780\n' +
-                'isdb>';
-        }
-        return ' \n' +
-        ' + user.dir =  C:\\Bases\\Amcm\\20.20 \n' +
-        'isdb>';
-    }
-
-}
-
-class HitBreakpointPartialFileNameWithSeparatorProvider extends BaseMockProvider {
-
-    private stage: Stage = Stage.Step;
-
-    getOutputContent(): string {
-        if (this.stage == Stage.Step) {
-            this.stage = Stage.GetCurrentDirectory;
-            return ' \n' +
-                ' + hit breakpoint in paragraph PCPR-CONFIGURACAO, file PDV201.CBL\n' +
-                ' line=75151 file=PDV201.CBL\n' +
-                '         pcpr-configuracao.                                                                                                *>  107606     780\n' +
-                'isdb>';
-        }
-        return ' \n' +
-        ' + user.dir =  C:\\Bases\\Amcm\\20.20\\ \n' +
-        'isdb>';
     }
 
 }

--- a/src/test/debugProcess/RequestAvailableSourceDirectoriesCommand.test.ts
+++ b/src/test/debugProcess/RequestAvailableSourceDirectoriesCommand.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import 'mocha';
+import { ICommand } from '../../debugProcess/DebugConfigs';
+import { RequestAvailableSourceDirectoriesCommand } from '../../debugProcess/RequestAvailableSourceDirectoriesCommand';
+
+const COMMAND: ICommand = {
+    name: 'display -env java.class.path',
+    successRegularExpression: '.*java\\.class\\.path\\s+=\\s+(?<directories>.*)'
+}
+
+describe('Request available source directories command', () => {
+
+    it('Checks a single available directory', () => {
+        const output =
+            ' \n' +
+            ' + java.class.path = F:\\SIGER\\wc\\DES\\cassel\\bin\\isCOBOL\\debug\n' +
+            'isdb>';
+        const expected: string[] = ['F:\\SIGER\\wc\\DES\\cassel\\bin\\isCOBOL\\debug'];
+        const result = new RequestAvailableSourceDirectoriesCommand(COMMAND).validateOutput(output);
+        expect(expected.length).to.equal(result!.length);
+        expect(expected[0]).to.equal(result![0]);
+    });
+
+    it('Checks two available directories', () => {
+        const output =
+            ' \n' +
+            ' + java.class.path = F:\\SIGER\\wc\\DES\\cassel\\bin\\isCOBOL\\debug;F:\\SIGER\\wc\\DES\\cassel\\src\\isCOBOL\\debug\n' +
+            'isdb>';
+        const expected: string[] = ['F:\\SIGER\\wc\\DES\\cassel\\bin\\isCOBOL\\debug', 'F:\\SIGER\\wc\\DES\\cassel\\src\\isCOBOL\\debug'];
+        const result = new RequestAvailableSourceDirectoriesCommand(COMMAND).validateOutput(output);
+        expect(expected.length).to.equal(result!.length);
+        expect(expected[0]).to.equal(result![0]);
+        expect(expected[1]).to.equal(result![1]);
+    });
+
+});
+


### PR DESCRIPTION
Now debug adapter looks for fallback directories in order to find files when external debugger does not provide the full file name.