### PR TITLE
SPDX license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"vscode": "^1.47.0"
 	},
 	"icon": "images/debugger-logo.png",
-	"license": "SEE LICENSE IN LICENSE.txt",
+	"license": "MIT",
 	"keywords": [
 		"rech cobol debugger cobol"
 	],


### PR DESCRIPTION
The vsix docs mentioned the currently used "SEE LICENSE in..." but refers to npm which says:

> You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it.
> If you're using a common license such as BSD-2-Clause or MIT, add a current SPDX license identifier for the license you're using, 
> `{ "license" : "BSD-3-Clause" }`, like this:
> [...] If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one:
> `{ "license" : "SEE LICENSE IN <filename>" }`
> Then include a file named <filename> at the top level of the package.

This PR is therefore changing that in accordance to the documentation. If I remember correctly this also fixes npm (linter/check?) warnings.